### PR TITLE
ISSUE : Ghost cannot update post if image Link contains space

### DIFF
--- a/index.js
+++ b/index.js
@@ -37,7 +37,7 @@ class RokkaAdapter extends BaseAdapter {
       }
       this.rokka.sourceimages.create(this.org, image.originalname, stream, meta).then(res => {
         const rokkaImage = res.body.items[0]
-        const link = 'https://' + this.org + '.rokka.io/' + this.defaultStack + '/' + rokkaImage.short_hash + '/' + rokkaImage.name
+        const link = 'https://' + this.org + '.rokka.io/' + this.defaultStack + '/' + rokkaImage.short_hash + '/' + encodeURIComponent(rokkaImage.name)
         debug('Uploaded:', link)
         resolve(link)
 


### PR DESCRIPTION
When uploading an image containing space in its name, Rokka plugin returns a link contains this space. This generated URL does not pass the Ghost post validation, producing the following error :

```
Validation failed for feature_image.

Error ID:
    e791e2b0-f911-11eb-b530-e7c22065bbd2

Details:
    keyword:    format
    dataPath:   .posts[0].feature_image
    schemaPath: #/properties/feature_image/format
    params: 
      format: uri-reference
    message:    should match format "uri-reference"
```

Fixed bu using `encodeURIComponent()` for the image name